### PR TITLE
Fix missing variable in ESP_LOGI call

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -177,7 +177,7 @@ void MatrixPanel_I2S_DMA::configureDMA(const HUB75_I2S_CFG& _cfg)
 
     } // end frame rows
 
-    ESP_LOGI(TAG, "%d DMA descriptors linked to buffer data.");
+    ESP_LOGI(TAG, "%d DMA descriptors linked to buffer data.", current_dmadescriptor_offset);
 
 //  
 //    Setup DMA and Output to GPIO


### PR DESCRIPTION
This log line was broken in https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/commit/7628be00c2a99f7189d2498f36e0e7857a371440 and causes a build error for esp-idf.