### PR TITLE
BCM accumulation correction

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -692,7 +692,6 @@ void MatrixPanel_I2S_DMA::brtCtrlOEv2(uint8_t brt, const int _buff_id) {
     brt = 0;
 */
 
-  int brightness_in_x_pixels = PIXELS_PER_ROW * ((float)brt/256);
   
   //Serial.println(brightness_in_x_pixels, DEC);
   uint8_t _blank 			 = m_cfg.latch_blanking; // don't want to inadvertantly blast over this
@@ -706,6 +705,7 @@ void MatrixPanel_I2S_DMA::brtCtrlOEv2(uint8_t brt, const int _buff_id) {
     // let's set OE control bits for specific pixels in each color_index subrows
     uint8_t colouridx = dma_buff.rowBits[row_idx]->colour_depth;
     do {
+        int brightness_in_x_pixels = PIXELS_PER_ROW * brt >> 8 + max( ( dma_buff.rowBits[row_idx]->colour_depth - colouridx - 2 ), 0);
       --colouridx;
 
       // switch pointer to a row for a specific color index


### PR DESCRIPTION
resolves #373 

before correction:
![20230120_133834](https://user-images.githubusercontent.com/46141631/213625174-24d5bac6-34f6-48c6-922f-afb42b16d496.jpg)

after correction:
![20230120_132956](https://user-images.githubusercontent.com/46141631/213625222-f4a95251-7afc-4b6b-b17a-c82908cb26c4.jpg)

