### PR TITLE
fix: _dmadesc_ loopc

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -831,8 +831,11 @@ void MatrixPanel_I2S_DMA::hlineDMA(int16_t x_coord, int16_t y_coord, int16_t l, 
   if ( !initialized )
     return;
 
-  if ( x_coord < 0 || y_coord < 0 || l < 1 || x_coord >= PIXELS_PER_ROW || y_coord >= m_cfg.mx_height)
+  if ( (x_coord + l) < 1 || y_coord < 0 || l < 1 || x_coord >= PIXELS_PER_ROW || y_coord >= m_cfg.mx_height)
     return;
+
+  l = x_coord < 0 ? l+x_coord : l;
+  x_coord = x_coord < 0 ? 0 : x_coord;
 
 
   l = ( (x_coord + l) >= PIXELS_PER_ROW ) ? (PIXELS_PER_ROW - x_coord):l; 
@@ -923,8 +926,11 @@ void MatrixPanel_I2S_DMA::vlineDMA(int16_t x_coord, int16_t y_coord, int16_t l, 
   if ( !initialized )
     return;
 
-  if ( x_coord < 0 || y_coord < 0 || l < 1 || x_coord >= PIXELS_PER_ROW || y_coord >= m_cfg.mx_height)
+  if ( x_coord < 0 || (y_coord + l) < 1 || l < 1 || x_coord >= PIXELS_PER_ROW || y_coord >= m_cfg.mx_height)
     return;
+
+  l = y_coord < 0 ? l+y_coord : l;
+  y_coord = y_coord < 0 ? 0 : y_coord;
 
   // check for a length that goes beyond the height of the screen! Array out of bounds dma memory changes = screwed output #163
   l = ( (y_coord + l) >= m_cfg.mx_height ) ? (m_cfg.mx_height - y_coord):l; 

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -274,7 +274,7 @@ struct  HUB75_I2S_CFG {
   bool clkphase;
 
   // Minimum refresh / scan rate needs to be configured on start due to LSBMSB_TRANSITION_BIT calculation in allocateDMAmemory()
-  uint8_t min_refresh_rate;
+  uint16_t min_refresh_rate;
 
   // struct constructor
   HUB75_I2S_CFG (
@@ -290,7 +290,7 @@ struct  HUB75_I2S_CFG {
     clk_speed _i2sspeed = HZ_15M,
     uint8_t _latblk  = DEFAULT_LAT_BLANKING, // Anything > 1 seems to cause artefacts on ICS panels
     bool _clockphase = true,
-    uint8_t _min_refresh_rate = 60
+    uint16_t _min_refresh_rate = 60
   ) : mx_width(_w),
       mx_height(_h),
       chain_length(_chain),

--- a/src/platforms/esp32/esp32_i2s_parallel_dma.cpp
+++ b/src/platforms/esp32/esp32_i2s_parallel_dma.cpp
@@ -61,7 +61,7 @@ static void IRAM_ATTR irq_hndlr(void* arg) { // if we use I2S1 (default)
 	void IRAM_ATTR irq_hndlr(void* arg) { 
 
 		// Clear flag so we can get retriggered
-		//SET_PERI_REG_BITS(I2S_INT_CLR_REG(ESP32_I2S_DEVICE), I2S_OUT_EOF_INT_CLR_V, 1, I2S_OUT_EOF_INT_CLR_S);                      
+		SET_PERI_REG_BITS(I2S_INT_CLR_REG(ESP32_I2S_DEVICE), I2S_OUT_EOF_INT_CLR_V, 1, I2S_OUT_EOF_INT_CLR_S);                      
 
 		active_dma_buffer_output_count++;
 
@@ -636,40 +636,29 @@ static void IRAM_ATTR irq_hndlr(void* arg) { // if we use I2S1 (default)
       if ( current_back_buffer_id == 1) { 
 	  //  _dmadesc_b is not visable, make it visible. Currently looping around _dmadesc_a
 	  //  GFX library is changing pixels of back buffer '1' 
-	  
-	    _dev->int_clr.out_eof = 1; // clear interrupt		
-        active_dma_buffer_output_count = 0;  
-        while (!active_dma_buffer_output_count) {}      
-		
+	     
         _dmadesc_a[_dmadesc_last].qe.stqe_next = &_dmadesc_b[0]; // Start sending out _dmadesc_b (or buffer 1)
-		current_back_buffer_id = 0;		// quickly update the library so it stops writing dirrectly to buffer 1!
-		
-	    _dev->int_clr.out_eof = 1; // clear interrupt		
+				
         active_dma_buffer_output_count = 0;  
         while (!active_dma_buffer_output_count) {}      		
-		
-        _dmadesc_a[_dmadesc_last].qe.stqe_next = &_dmadesc_a[0]; // get this preped for the next flip buffer
+
+        //fix _dmadesc_ loop issue #407
+        //need to connect the up comming _dmadesc_ not the old one
+        _dmadesc_b[_dmadesc_last].qe.stqe_next = &_dmadesc_b[0];
 		      
       } else { 
 	  // current_back_buffer_id == 0
 	  // we are currently active on _dmadesc_a. we want to flip across and loop _dmadesc_
 	  
-	    _dev->int_clr.out_eof = 1; // clear interrupt		
-        active_dma_buffer_output_count = 0;  
-        while (!active_dma_buffer_output_count) {} 
-		
         _dmadesc_b[_dmadesc_last].qe.stqe_next = &_dmadesc_a[0]; 
-		current_back_buffer_id = 1;		
 
-	    _dev->int_clr.out_eof = 1; // clear interrupt		
         active_dma_buffer_output_count = 0;  
         while (!active_dma_buffer_output_count) {}    
   
-        _dmadesc_b[_dmadesc_last].qe.stqe_next = &_dmadesc_b[0];
-		
+        _dmadesc_a[_dmadesc_last].qe.stqe_next = &_dmadesc_a[0];
 		
       }
-       // current_back_buffer_id ^= 1;            
+      current_back_buffer_id ^= 1;            
 
       // Disable intterupt  
       _dev->int_ena.out_eof = 0;      


### PR DESCRIPTION
fix: _dmadesc_ loop -> better Image quality
fix: min_refresh_rate to uint16_t -> higher min_refresh_rate possible
fix: hlineDMA and vlineDMA when line starts off matrix it is now partially drawn instead of not at all -> used in Text when size > 1 and letter is scrolling out

check issue #407