### PR TITLE
`esp-idf`: Add menuconfig option `ESP32_HUB75_USE_GFX`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,10 @@
 cmake_minimum_required(VERSION 3.5)
 idf_build_get_property(target IDF_TARGET)
 
-if(ARDUINO_ARCH_ESP32)
-    list(APPEND arduino_build arduino Adafruit-GFX-Library)
+if(ARDUINO_ARCH_ESP32 OR CONFIG_ESP32_HUB75_USE_GFX)
+    list(APPEND build_dependencies arduino Adafruit-GFX-Library)
 else()
-    list(APPEND esp_idf_build esp_lcd driver)
+    list(APPEND build_dependencies esp_lcd driver)
 endif()
 
 if(${target} STREQUAL "esp32s3")
@@ -17,8 +17,17 @@ endif()
 
 idf_component_register(SRCS "src/platforms/esp32/esp32_i2s_parallel_dma.cpp" "src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp" "src/ESP32-HUB75-MatrixPanel-leddrivers.cpp" ${extra_srcs}
                        INCLUDE_DIRS "./src"
-                       REQUIRES ${arduino_build} ${esp_idf_build}
                        )
+
+# Dependencies cannot be added to the REQUIRES argument of `idf_component_register` because (according to the build process
+# listed at https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-guides/build-system.html#build-process)
+# `idf_component_register` is processed during the "Enumeration" stage which happens before the sdkconfig file is loaded
+# in the "Processing" stage. So if dependencies are going to be loaded based on certain CONFIG_* variables we must
+# use `target_link_libraries` instead. This is the method used by Arduino's CMakeLists.txt file.
+foreach(component_name IN LISTS build_dependencies)
+  idf_component_get_property(lib_name ${component_name} COMPONENT_LIB)
+  target_link_libraries(${COMPONENT_LIB} PUBLIC ${lib_name})
+endforeach()
 
 # In case you are running into issues with "missing" header files from 3rd party libraries
 # you can add them to the REQUIRES section above. If you use some of the build options below
@@ -29,7 +38,7 @@ idf_component_register(SRCS "src/platforms/esp32/esp32_i2s_parallel_dma.cpp" "sr
 # target_compile_options(${COMPONENT_TARGET} PUBLIC -DNO_GFX)
 
 # esp-idf does not have any GFX library support yet, so we need to define NO_GFX
-if(ARDUINO_ARCH_ESP32)
+if(ARDUINO_ARCH_ESP32 OR CONFIG_ESP32_HUB75_USE_GFX)
 else()
     target_compile_options(${COMPONENT_TARGET} PUBLIC -DNO_GFX)
     if(${target} STREQUAL "esp32s3")

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -1,0 +1,9 @@
+menu "ESP32 HUB75 Configuration"
+
+  config ESP32_HUB75_USE_GFX
+      bool "Use Adafruit GFX library."
+      default y
+      help
+          This option enables use of the Adafruit GFX library using the `Adafruit-GFX-Library` component.
+
+endmenu

--- a/src/platforms/esp32/esp32_i2s_parallel_dma.cpp
+++ b/src/platforms/esp32/esp32_i2s_parallel_dma.cpp
@@ -28,7 +28,10 @@ Modified heavily for the ESP32 HUB75 DMA library by:
 #include <driver/periph_ctrl.h>
 #include <soc/gpio_sig_map.h>
 
-#include <Arduino.h> // Need to make sure this is uncommented to get ESP_LOG output on (Arduino) Serial output!!!!
+#if defined (ARDUINO_ARCH_ESP32)
+#include <Arduino.h>
+#endif
+
 #include <esp_err.h>
 #include <esp_log.h>
 


### PR DESCRIPTION
This pull requests adds a menuconfig option named `ESP32_HUB75_USE_GFX` which is used to determine if the Adafruit GFX component should be required and used for the build. menuconfig options are the standard way to change behavior of components in `esp-idf`.

[Commit b8367d9](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/commit/b8367d95d20da4edd149f207dd86665c3cc70588) introduced a backwards incompatible change that caused `idf-idf` to only require the Adafruit-GFX-Library component if `ARDUINO_ARCH_ESP32` was set. `ARDUINO_ARCH_ESP32` is set in platformIO, the arduino software but not in the standalone `esp-idf` installation.