### PR TITLE
Pin platformio to verison 6.1.6.

### DIFF
--- a/.github/workflows/pio_build.yml
+++ b/.github/workflows/pio_build.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install Platformio
-      run: pip install --upgrade platformio
+      run: pip install --upgrade platformio==6.1.6
     - name: Run PlatformIO CI (Arduino)
       if: ${{ matrix.framework == 'Arduino'}}
       env: 


### PR DESCRIPTION
Version 6.1.7 was released on 2023-05-08 and all CI runs are failing with:

```
Error: Not a PlatformIO project. `platformio.ini` file has not been found in current working directory (examples/PIO_TestPatterns). To initialize new project please use `platformio project init` command
```

The new release notes are here: https://docs.platformio.org/en/latest/core/history.html#id2. Perhaps this breakage has something to do with new validation that `project working environment names ... only contain lowercase letters a-z, numbers 0-9, and special characters _ (underscore) and - (hyphen)` while this repo uses an example named `PIO_TestPatterns`?

Let's pin ourselves to a known good version so we can fix the issue and then choose when to upgrade in the future without causing unexpected breakages.