### PR TITLE
Add fatal `message()` when a required component is not found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,11 @@ idf_component_register(SRCS "src/platforms/esp32/esp32_i2s_parallel_dma.cpp" "sr
 # `idf_component_register` is processed during the "Enumeration" stage which happens before the sdkconfig file is loaded
 # in the "Processing" stage. So if dependencies are going to be loaded based on certain CONFIG_* variables we must
 # use `target_link_libraries` instead. This is the method used by Arduino's CMakeLists.txt file.
+idf_build_get_property(components BUILD_COMPONENTS)
 foreach(component_name IN LISTS build_dependencies)
+  if (NOT ${component_name} IN_LIST components)
+    message(FATAL_ERROR "Missing component: ${component_name}")
+  endif()
   idf_component_get_property(lib_name ${component_name} COMPONENT_LIB)
   target_link_libraries(${COMPONENT_LIB} PUBLIC ${lib_name})
 endforeach()


### PR DESCRIPTION
Without this nice formatting of the error, `idf.py build` returns a cryptic error (`__component_get_property Function invoked with incorrect arguments`).