### PR TITLE
Remove `.github` exclusion for triggering workflows.

### DIFF
--- a/.github/workflows/esp-idf_with-gfx.yml
+++ b/.github/workflows/esp-idf_with-gfx.yml
@@ -5,12 +5,10 @@ on:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
   pull_request:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/esp-idf_without-gfx.yml
+++ b/.github/workflows/esp-idf_without-gfx.yml
@@ -5,12 +5,10 @@ on:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
   pull_request:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/pio_build.yml
+++ b/.github/workflows/pio_build.yml
@@ -10,13 +10,11 @@ on:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
   pull_request:
     branches: [ master, dev ]
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/**'
 
 jobs:
   build:


### PR DESCRIPTION
I believe that we want to trigger actions/workflows when the workflow files in .github/workflows are updated; this is how we will know that they work :)