### PR TITLE
Support for DP3246 / SM5368 based panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Due to the high-speed optimized nature of this library, only specific panels are
 * ICND2012
 * [RUC7258](http://www.ruichips.com/en/products.html?cateid=17496)
 * FM6126A AKA ICN2038S, [FM6124](https://datasheet4u.com/datasheet-pdf/FINEMADELECTRONICS/FM6124/pdf.php?id=1309677) (Refer to [PatternPlasma](/examples/2_PatternPlasma) example on how to use.)
-* SM5266P 
+* SM5266P
+* DP3246 with SM5368 row addressing registers
 
 ## Unsupported chips
 * [SM1620B](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/issues/416)
@@ -95,7 +96,7 @@ Please use an [alternative library](https://github.com/2dom/PxMatrix) if you bou
 # Getting Started
 ## 1. Library Installation
 
-* Dependancy: You will need to install Adafruit_GFX from the "Library > Manage Libraries" menu.
+* Dependency: You will need to install Adafruit_GFX from the "Library > Manage Libraries" menu.
 * Install this library from the Arduino Library manager.
 
 Library also tested to work fine with PlatformIO, install into your PlatformIO projects' lib/ folder as appropriate. Or just add it into [platformio.ini](/doc/BuildOptions.md) [lib_deps](https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps) section.

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -243,7 +243,8 @@ struct HUB75_I2S_CFG
     FM6126A,
     ICN2038S,
     MBI5124,
-    SM5266P
+    SM5266P,
+    DP3246_SM5368
   };
 
   /**
@@ -767,6 +768,11 @@ private:
    * @brief - FM6124-family chips initialization routine
    */
   void fm6124init(const HUB75_I2S_CFG &_cfg);
+
+  /**
+   * @brief - DP3246-family chips initialization routine
+   */
+  void dp3246init(const HUB75_I2S_CFG& _cfg);
 
   /**
    * @brief - reset OE bits in DMA buffer in a way to control brightness

--- a/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
@@ -126,7 +126,7 @@ void MatrixPanel_I2S_DMA::dp3246init(const HUB75_I2S_CFG& _cfg) {
     bool REG2[16] = { 1,1,1,1,1, 1,1,1, 0, 0, 0, 0, 0, 0,0,0 };  // MSB first
 
     for (uint8_t _pin : {_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2, _cfg.gpio.clk, _cfg.gpio.lat, _cfg.gpio.oe}) {
-        gpio_reset_pin((gpio_num_t)_pin);                        // some pins are not un gpio mode after reset => https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
+        gpio_reset_pin((gpio_num_t)_pin);                        // some pins are not in gpio mode after reset => https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
         gpio_set_direction((gpio_num_t)_pin, GPIO_MODE_OUTPUT);
         gpio_set_level((gpio_num_t)_pin, LOW);
     }

--- a/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
@@ -27,6 +27,9 @@ void MatrixPanel_I2S_DMA::shiftDriver(const HUB75_I2S_CFG& _cfg){
     case HUB75_I2S_CFG::FM6126A:
         fm6124init(_cfg);
         break;
+    case HUB75_I2S_CFG::DP3246_SM5368:
+        dp3246init(_cfg);
+        break;
     case HUB75_I2S_CFG::MBI5124:
         /* MBI5124 chips must be clocked with positive-edge, since it's LAT signal
         * resets on clock's rising edge while high
@@ -96,5 +99,77 @@ void MatrixPanel_I2S_DMA::fm6124init(const HUB75_I2S_CFG& _cfg) {
     CLK_PULSE
     gpio_set_level((gpio_num_t) _cfg.gpio.lat, LOW);
     gpio_set_level((gpio_num_t) _cfg.gpio.oe, LOW); // Enable Display
+    CLK_PULSE
+}
+
+void MatrixPanel_I2S_DMA::dp3246init(const HUB75_I2S_CFG& _cfg) {
+
+    ESP_LOGI("LEDdrivers", "MatrixPanel_I2S_DMA - initializing DP3246 driver...");
+
+    // 15:13   3   000        reserved
+    // 12:9    4   0000       OE widening (= OE_ADD * 6ns)
+    // 8       1   0          reserved
+    // 7:0     8   11111111   Iout = (Igain+1)/256 * 17.6 / Rext
+    bool REG1[16] = { 0,0,0, 0,0,0,0, 0, 1,1,1,1,1,1,1,1 };  // MSB first
+
+    // 15:11   5   11111      Blanking potential selection, step 77mV, 00000: VDD-0.8V
+    // 10:8    3   111        Constant current source output inflection point selection
+    // 7       1   0          Disable dead pixel removel, 1: Enable
+    // 6       1   0          0->1: (OPEN_DET rising edge) start detection, 0: reset to ready-to-detect state
+    // 5       1   0          0: Enable black screen power saving, 1: Turn off the black screen to save energy
+    // 4       1   0          0: Do not enable the fading function, 1: Enable the fade function
+    // 3       1   0          Reserved
+    // 2:0     3   000        000: single edge pass, others: double edge transfer
+    bool REG2[16] = { 1,1,1,1,1, 1,1,1, 0, 0, 0, 0, 0, 0,0,0 };  // MSB first
+
+    for (uint8_t _pin : {_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2, _cfg.gpio.clk, _cfg.gpio.lat, _cfg.gpio.oe}) {
+        gpio_set_direction((gpio_num_t)_pin, GPIO_MODE_OUTPUT);
+        gpio_set_level((gpio_num_t)_pin, LOW);
+    }
+
+    gpio_set_level((gpio_num_t)_cfg.gpio.oe, HIGH); // disable Display
+
+    // Send Data to control register REG1
+    for (int l = 0; l < PIXELS_PER_ROW; l++) {
+        for (uint8_t _pin : {_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2})
+            gpio_set_level((gpio_num_t)_pin, REG1[l % 16]);   // we have 16 bits shifters and write the same value all over the matrix array
+
+        if (l == PIXELS_PER_ROW - 11) {         // pull the latch 11 clocks before the end of matrix so that REG1 starts counting to save the value
+            gpio_set_level((gpio_num_t)_cfg.gpio.lat, HIGH);
+        }
+        CLK_PULSE
+    }
+
+    // drop the latch and save data to the REG1 all over the DP3246 chips
+    gpio_set_level((gpio_num_t)_cfg.gpio.lat, LOW);
+
+    // Send Data to control register REG2
+    for (int l = 0; l < PIXELS_PER_ROW; l++) {
+        for (uint8_t _pin : {_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2})
+            gpio_set_level((gpio_num_t)_pin, REG2[l % 16]);   // we have 16 bits shifters and we write the same value all over the matrix array
+
+        if (l == PIXELS_PER_ROW - 12) {       // pull the latch 12 clocks before the end of matrix so that REG2 starts counting to save the value
+            gpio_set_level((gpio_num_t)_cfg.gpio.lat, HIGH);
+        }
+        CLK_PULSE
+    }
+
+    // drop the latch and save data to the REG2 all over the DP3246 chips
+    gpio_set_level((gpio_num_t)_cfg.gpio.lat, LOW);
+    CLK_PULSE
+
+    // blank data regs to keep matrix clear after manipulations
+    for (uint8_t _pin : {_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2})
+        gpio_set_level((gpio_num_t)_pin, LOW);
+
+    for (int l = 0; l < PIXELS_PER_ROW; ++l) {
+        if (l == PIXELS_PER_ROW - 3) {       // DP3246 wants the latch dropped for 3 clk cycles
+            gpio_set_level((gpio_num_t)_cfg.gpio.lat, HIGH);
+        }
+        CLK_PULSE
+    }
+
+    gpio_set_level((gpio_num_t)_cfg.gpio.lat, LOW);
+    gpio_set_level((gpio_num_t)_cfg.gpio.oe, LOW); // enable Display
     CLK_PULSE
 }


### PR DESCRIPTION
I've picked up a weird 256x128 1/32 scan panel that uses DP3246 line registers  and SM5368 registers for row selection from [AliExpress](https://www.aliexpress.com/item/1005001958540336.html).
The key changes are:

- the DP3246 registers need to be initialised, similar to FM6124 (see datasheet for details)
- they require the latch to be active over a 3 clock cycle. The datasheet also mentions 4 and 5 clock cycles which I don't fully understand and couldn't get to work
- row addressing works via shift register using only pins A, B and C, with row clock on A, data on C and BK on B.

This PR adds the option for selecting both chipsets, DP3246 and SM5368, at the same time. In case there are other panels that use either of them in combination with other chipsets you might want to split up the enum and allow for both being configured independently.

Note: somehow my panel also has the red and blue pins crossed over, so if the colours come out wrong try switching the pins (R1<->B1, R2<->B2).

Here's a translation of the DP3216 datasheet:
[DP3246_datasheet_CN_2021_V1 2.pdf](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/files/11953174/DP3246_datasheet_CN_2021_V1.2.pdf)


![PXL_20230701_020655947](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/assets/3577835/1ae8b92f-c874-4d69-8af1-7f2f2321b74c)
![PXL_20230701_020508067](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/assets/3577835/b2e17c4a-14e5-48df-9748-4ad50851122f)
![PXL_20230701_020550825](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/assets/3577835/fc6ed0bc-540f-43fa-8ed3-90ad974fb771)
![PXL_20230701_020641128](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/assets/3577835/fc1b26e4-7465-401a-a974-97604ed5e262)
