### PR TITLE
Bugfix/init gpio

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
@@ -49,6 +49,7 @@ void MatrixPanel_I2S_DMA::fm6124init(const HUB75_I2S_CFG& _cfg) {
     bool REG2[16] = {0,0,0,0,0, 0,0,0,0,1,0, 0,0,0,0,0};    // a single bit enables the matrix output
 
     for (uint8_t _pin:{_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2, _cfg.gpio.clk, _cfg.gpio.lat, _cfg.gpio.oe}){
+        gpio_reset_pin((gpio_num_t)_pin);                        // some pins are not un gpio mode after reset => https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
         gpio_set_direction((gpio_num_t) _pin, GPIO_MODE_OUTPUT);
         gpio_set_level((gpio_num_t) _pin, LOW);
     }

--- a/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
@@ -49,7 +49,7 @@ void MatrixPanel_I2S_DMA::fm6124init(const HUB75_I2S_CFG& _cfg) {
     bool REG2[16] = {0,0,0,0,0, 0,0,0,0,1,0, 0,0,0,0,0};    // a single bit enables the matrix output
 
     for (uint8_t _pin:{_cfg.gpio.r1, _cfg.gpio.r2, _cfg.gpio.g1, _cfg.gpio.g2, _cfg.gpio.b1, _cfg.gpio.b2, _cfg.gpio.clk, _cfg.gpio.lat, _cfg.gpio.oe}){
-        gpio_reset_pin((gpio_num_t)_pin);                        // some pins are not un gpio mode after reset => https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
+        gpio_reset_pin((gpio_num_t)_pin);                        // some pins are not in gpio mode after reset => https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
         gpio_set_direction((gpio_num_t) _pin, GPIO_MODE_OUTPUT);
         gpio_set_level((gpio_num_t) _pin, LOW);
     }


### PR DESCRIPTION
I've had an issue when using pins that are not connected to GPIO after reset (e.g. 12, 15) and that need to be configured for GPIO first. `gpio_reset_pin  ensures that they are correctly initialised.
See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#gpio-summary
