### PR TITLE
Add name to esp-idf workflows.

### DIFF
--- a/.github/workflows/esp-idf_with-gfx.yml
+++ b/.github/workflows/esp-idf_with-gfx.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: esp-idf with Adafruit GFX
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/esp-idf_without-gfx.yml
+++ b/.github/workflows/esp-idf_without-gfx.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: esp-idf without Adafruit GFX
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Without these names, the checks just appear as "build" in the actions (example: https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/pull/475 Click on "View Details" next to the merge message)