### PR TITLE
minimal optimization and adjustment

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -347,9 +347,9 @@ void IRAM_ATTR MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint16_t x_coord, uint
   green16 = lumConvTab[green];
   blue16 = lumConvTab[blue];
 #else
-  red16 = red << 8;
-  green16 = green << 8;
-  blue16 = blue << 8;
+  red16 = red << 8 | red;
+  green16 = green << 8 | green;
+  blue16 = blue << 8 | blue;
 #endif
 
   /* When using the drawPixel, we are obviously only changing the value of one x,y position,

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -880,9 +880,12 @@ private:
  */
 inline void MatrixPanel_I2S_DMA::color565to888(const uint16_t color, uint8_t &r, uint8_t &g, uint8_t &b)
 {
-  r = ((((color >> 11) & 0x1F) * 527) + 23) >> 6;
-  g = ((((color >> 5) & 0x3F) * 259) + 33) >> 6;
-  b = (((color & 0x1F) * 527) + 23) >> 6;
+  r = (color >> 8) & 0xf8;
+  g = (color >> 3) & 0xfc;
+  b = (color << 3) & 0xf8;
+  r |= r >> 5;
+  g |= g >> 6;
+  b |= b >> 5;
 }
 
 inline void MatrixPanel_I2S_DMA::drawPixel(int16_t x, int16_t y, uint16_t color) // adafruit virtual void override

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -882,7 +882,7 @@ inline void MatrixPanel_I2S_DMA::color565to888(const uint16_t color, uint8_t &r,
 {
   r = (color >> 8) & 0xf8;
   g = (color >> 3) & 0xfc;
-  b = (color << 3) & 0xf8;
+  b = (color << 3);
   r |= r >> 5;
   g |= g >> 6;
   b |= b >> 5;


### PR DESCRIPTION
- i removed multiplication from color565to888(). don't know if a multiplication nowadays still is more expensiv than bit shifting.
- i guess when NO_CIE1931 is defined, then red16, green16 blue16 can never reach it maximum 0xffff value.