### PR TITLE
make a d-tor virtual

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -462,9 +462,8 @@ public:
   }
 
   // Obj destructor
-  ~MatrixPanel_I2S_DMA()
+  virtual ~MatrixPanel_I2S_DMA()
   {
-
     dma_bus.release();
   }
 


### PR DESCRIPTION
since a d-tor is non-trivial, it should be virtual if MatrixPanel_I2S_DMA is used as a base class