### PR TITLE
NO_GFX fixes for VirtualPanel and width/height

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -571,6 +571,11 @@ public:
   void drawPixel(int16_t x, int16_t y, CRGB color);
 #endif
 
+#ifdef NO_GFX
+    inline int16_t width() const { return m_cfg.mx_width * m_cfg.chain_length; }
+    inline int16_t height() const { return m_cfg.mx_height; }
+#endif
+
   void drawIcon(int *ico, int16_t x, int16_t y, int16_t cols, int16_t rows);
 
   // Colour 444 is a 4 bit scale, so 0 to 15, colour 565 takes a 0-255 bit value, so scale up by 255/15 (i.e. 17)!

--- a/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -124,6 +124,11 @@ public:
     void drawPixel(int16_t x, int16_t y, CRGB color);
 #endif
 
+#ifdef NO_GFX
+    inline int16_t width() const { return _virtualResX; }
+    inline int16_t height() const { return _virtualResY; }
+#endif
+
     uint16_t color444(uint8_t r, uint8_t g, uint8_t b)
     {
         return display->color444(r, g, b);
@@ -479,6 +484,9 @@ inline void VirtualMatrixPanel::setRotation(uint8_t rotate)
 
   // Change the _width and _height variables used by the underlying adafruit gfx library.
   // Actual pixel rotation / mapping is done in the getCoords function.
+#ifdef NO_GFX
+    int8_t rotation;
+#endif
   rotation = (rotate & 3);
   switch (rotation) {
   case 0: // nothing


### PR DESCRIPTION
When Building with NO_GFX neither VirtualMatrixPanel nor MatrixPanel_I2S_DMA have a height or width function. In the basic one, you could get the information with getCfg, but functions are the better way.
In VirtualMatrixPanel::setRotation  'rotation' is undeclared if build with NO_GFX