### PR TITLE
Include ZeDMD as cool use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ There are a number of great looking LED graphical display projects which leverag
 * [Aurora Audio Visualiser](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/discussions/188)
 * [Big Visualisation](https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/discussions/155)
 * [Clockwise](https://jnthas.github.io/clockwise/)
+* [ZeDMD](https://github.com/PPUC/ZeDMD)
 
 # Thank you!
 * [Brian Lough](https://www.tindie.com/stores/brianlough/) ([youtube link](https://www.youtube.com/c/brianlough)) for providing code contributions, hardware and suggestions


### PR DESCRIPTION
ZeDMD is a a "real" DMD for pinball emulations. I think this is a cool use-case worth to be mentioned.
Thanks for your great library!