### PR TITLE
Add esp_lcd dependency to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ endif()
 
 if(${target} STREQUAL "esp32s3")
   list(APPEND extra_srcs src/platforms/${target}/gdma_lcd_parallel16.cpp)
+
+  # Required by gdma_lcd_parallel16.cpp
+  if (NOT esp_lcd IN_LIST build_dependencies)
+    list(APPEND build_dependencies esp_lcd)
+  endif()
 endif()
 
 idf_component_register(SRCS "src/platforms/esp32/esp32_i2s_parallel_dma.cpp" "src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp" "src/ESP32-HUB75-MatrixPanel-leddrivers.cpp" ${extra_srcs}


### PR DESCRIPTION
When building for the ESP32-S3, `gdma_lcd_parallel16.cpp` depends on the `esp_lcd` library. However if you set `CONFIG_ESP32_HUB75_USE_GFX`, it is never added to the dependency list. This is just a simple fix that ensure that `esp_lcd` is always pulled in when the build target is the ESP32-S3.